### PR TITLE
Update alpha model for NAGL v0.3.x 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [macOS-latest, ubuntu-latest]
 
     steps:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,3 +10,4 @@ dependencies:
 
     # Testing
   - pytest
+  - openff-nagl>=0.3.0rc1

--- a/openff/nagl_models/tests/test_model_performance.py
+++ b/openff/nagl_models/tests/test_model_performance.py
@@ -1,0 +1,31 @@
+import pytest
+import numpy as np
+
+pytest.importorskip("openff.nagl")
+
+
+@pytest.mark.parametrize(
+    "model_file, expected_charges",
+    [
+        (
+            "openff-gnn-am1bcc-0.0.1-alpha.1.pt",
+            [-0.119291  ,  0.12953702, -0.60555816,  0.04394022, 
+             0.04394018, 0.04394022,  0.03412103,  0.034121  ,
+               0.39524958]
+        )
+    ]
+)
+def test_models_ethanol(model_file, expected_charges):
+    from openff.nagl.nn._models import GNNModel
+    from openff.toolkit import Molecule
+    from openff.nagl_models import validate_nagl_model_path
+
+    model_path = validate_nagl_model_path(model_file)
+    model = GNNModel.load(model_path, eval_mode=True)
+    ethanol = Molecule.from_smiles("CCO")
+    charges = model.compute_property(
+        ethanol,
+        readout_name="am1bcc-charges",
+        as_numpy=True
+    )
+    np.testing.assert_allclose(charges, expected_charges, atol=1e-5)


### PR DESCRIPTION
This updates the model shipped in `openff-nagl-models` to the openff-nagl 0.3.x architecture. It adds tests to ensure numerical consistency.