### PR TITLE
Drop `macos-12` from actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        os: [macOS-12, macOS-latest, ubuntu-latest]
+        os: [macOS-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is causing failures i.e. https://github.com/openforcefield/openff-nagl-models/actions/runs/12150527100/job/35078476334