### PR TITLE
Use stdlib `importlib` instead of backports

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,5 +12,3 @@ dependencies:
   - pytest
   - openff-nagl-base >=0.4.0
 
-  - pip:
-    - importlib_resources

--- a/openff/nagl_models/openff_nagl_models.py
+++ b/openff/nagl_models/openff_nagl_models.py
@@ -2,7 +2,7 @@
 This module only contains the function that will be the entry point that
 will be used to find the model files.
 """
-import importlib_resources
+import importlib.resources
 import os
 import pathlib
 import typing
@@ -22,7 +22,7 @@ def get_nagl_model_dirs_paths() -> list[pathlib.Path]:
         The list of directory paths containing the NAGL model files.
     """
     model_types = ["am1bcc"]
-    base = importlib_resources.files("openff.nagl_models")
+    base = importlib.resources.files("openff.nagl_models")
     return [base / "models" / model_type for model_type in model_types]
 
 
@@ -196,7 +196,7 @@ def get_models_by_type(
     """
     from packaging.version import Version
 
-    base_dir = importlib_resources.files("openff.nagl_models") / "models" / model_type
+    base_dir = importlib.resources.files("openff.nagl_models") / "models" / model_type
     if not os.path.isdir(base_dir):
         raise ValueError(
             f"Model type {model_type} not found in openff-nagl-models. "

--- a/openff/nagl_models/tests/test_openff_nagl_models.py
+++ b/openff/nagl_models/tests/test_openff_nagl_models.py
@@ -4,7 +4,7 @@ Unit and regression test for the openff_nagl_models package.
 
 import os
 import importlib.resources
-from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 import pytest
 from openff.nagl_models import validate_nagl_model_path, list_available_nagl_models


### PR DESCRIPTION
The third-party packages don't seem necessary anymore

https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files (3.9+)
https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.entry_points (mostly stable 3.10+) 