### PR TITLE
Broken navigation links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,7 @@ from importlib.util import find_spec as find_import_spec
 if find_import_spec("notfound"):
     extensions.append("notfound.extension")
 
-    notfound_urls_prefix = "/projects/nagl/en/stable/"
+    notfound_urls_prefix = "/projects/nagl-models/en/stable/"
     notfound_context = {
         "title": "404: File Not Found",
         "body": f"""


### PR DESCRIPTION
For some reason the links in the nav bar are pointing to NAGL rather than NAGL models: https://docs.openforcefield.org/projects/nagl-models/models/index.html